### PR TITLE
Slot render: use supplied pose stack instead of creating a new one

### DIFF
--- a/src/main/java/com/anthonyhilyard/itemborders/ItemBorders.java
+++ b/src/main/java/com/anthonyhilyard/itemborders/ItemBorders.java
@@ -41,7 +41,7 @@ public class ItemBorders implements ClientModInitializer
 		// If borders are enabled for the hotbar...
 		if (ItemBordersConfig.INSTANCE.hotBar.get())
 		{
-			render(new PoseStack(), item, x, y);
+			render(poseStack, item, x, y);
 		}
 	}
 


### PR DESCRIPTION
Creating a new pose stack breaks any mod that move the hotbar, such as Auto HUD or Raised. The item border would always be drawn at the vanilla hotbar position instead of where the item gets actually rendered. By using the pose stack as it was handed to the method, other mods' matrix translations will be respected. This properly anchors the border to the rendered item.

This PR is exemplary for the latest branch I could find, but applies the same to all versions of both Fabric and Forge.

Fixes #20 